### PR TITLE
Add stacktrace to the JSON message.

### DIFF
--- a/logging-fixtures/src/main/java/org/creekservice/api/test/observability/logging/structured/TestStructuredLogger.java
+++ b/logging-fixtures/src/main/java/org/creekservice/api/test/observability/logging/structured/TestStructuredLogger.java
@@ -75,7 +75,7 @@ public final class TestStructuredLogger implements StructuredLogger {
         final DefaultLogEntryCustomizer customizer = DefaultLogEntryCustomizer.create(message);
         customizeConsumer.accept(customizer);
 
-        entries.add(logEntry(level, customizer.build(), customizer.throwable()));
+        entries.add(logEntry(level, customizer.build(false), customizer.throwable()));
     }
 
     /**

--- a/logging/build.gradle.kts
+++ b/logging/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     testImplementation("com.github.spotbugs:spotbugs-annotations:$spotBugsVersion")
 
     // Required by Log4j when using JsonLayout:
-    testRuntimeOnly("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     // Required by Log4j when using XmlLayout:
     testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
 }

--- a/logging/src/main/java/org/creekservice/internal/observability/logging/structured/LogEntryFormatter.java
+++ b/logging/src/main/java/org/creekservice/internal/observability/logging/structured/LogEntryFormatter.java
@@ -16,6 +16,22 @@
 
 package org.creekservice.internal.observability.logging.structured;
 
+import java.util.Map;
+
+/** A formatter of log entries. */
 interface LogEntryFormatter {
-    String format(Object o);
+
+    /**
+     * @return {@code true} if any throwable should be included in the message payload in a `cause`
+     *     field, rather than passed to the underlying logging framework.
+     */
+    boolean causeInMessage();
+
+    /**
+     * Called to format a log entry.
+     *
+     * @param logEntry the log entry to format.
+     * @return the formatted data.
+     */
+    String format(Map<String, ?> logEntry);
 }

--- a/logging/src/main/java/org/creekservice/internal/observability/logging/structured/Slf4jStructuredLogger.java
+++ b/logging/src/main/java/org/creekservice/internal/observability/logging/structured/Slf4jStructuredLogger.java
@@ -82,8 +82,10 @@ public final class Slf4jStructuredLogger implements StructuredLogger {
         final DefaultLogEntryCustomizer customizer = customizerFactory.apply(message);
         customizeConsumer.accept(rootNs.map(customizer::ns).orElse(customizer));
 
-        slf4jLevel.log(
-                logger, formatter.format(customizer.build()), customizer.throwable().orElse(null));
+        final boolean causeInMsg = formatter.causeInMessage();
+        final Throwable cause = causeInMsg ? null : customizer.throwable().orElse(null);
+
+        slf4jLevel.log(logger, formatter.format(customizer.build(causeInMsg)), cause);
     }
 
     private interface EnabledMethod {

--- a/logging/src/test/java/module-info.test
+++ b/logging/src/test/java/module-info.test
@@ -1,8 +1,8 @@
 --add-modules
-  org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity
+  org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,com.fasterxml.jackson.databind
 
 --add-reads
-  creek.observability.logging=org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity
+  creek.observability.logging=org.junitpioneer,org.hamcrest,guava.testlib,creek.test.util,creek.test.hamcrest,creek.test.conformity,com.fasterxml.jackson.databind
 
 --add-opens
   org.junitpioneer/org.junitpioneer.jupiter=org.junit.platform.commons

--- a/logging/src/test/java/org/creekservice/internal/observability/logging/structured/DefaultLogEntryCustomizerTest.java
+++ b/logging/src/test/java/org/creekservice/internal/observability/logging/structured/DefaultLogEntryCustomizerTest.java
@@ -40,7 +40,7 @@ class DefaultLogEntryCustomizerTest {
 
     @Test
     void shouldSetMessage() {
-        assertThat(customizer.build(), is(Map.of("message", "log message")));
+        assertThat(customizer.build(false), is(Map.of("message", "log message")));
     }
 
     @Test
@@ -49,7 +49,7 @@ class DefaultLogEntryCustomizerTest {
         customizer.with("key", 10);
 
         // Then:
-        assertThat(customizer.build(), hasEntry("key", 10));
+        assertThat(customizer.build(false), hasEntry("key", 10));
     }
 
     @Test
@@ -58,7 +58,7 @@ class DefaultLogEntryCustomizerTest {
         customizer.with(MetricName.someMetric, 10);
 
         // Then:
-        assertThat(customizer.build(), hasEntry("someMetric", 10));
+        assertThat(customizer.build(false), hasEntry("someMetric", 10));
     }
 
     @Test
@@ -82,7 +82,7 @@ class DefaultLogEntryCustomizerTest {
         customizer.with("key", null);
 
         // Then:
-        assertThat(customizer.build(), not(hasKey("key")));
+        assertThat(customizer.build(false), not(hasKey("key")));
     }
 
     @Test
@@ -91,7 +91,7 @@ class DefaultLogEntryCustomizerTest {
         customizer.with(MetricName.someMetric, null);
 
         // Then:
-        assertThat(customizer.build(), not(hasKey("testKey")));
+        assertThat(customizer.build(false), not(hasKey("testKey")));
     }
 
     @Test
@@ -160,6 +160,43 @@ class DefaultLogEntryCustomizerTest {
     }
 
     @Test
+    void shouldBuildThrowableInMessage() {
+        // Given:
+        customizer.withThrowable(THROWABLE);
+
+        // When:
+        final Map<String, Object> msg = customizer.build(true);
+
+        // Then:
+        assertThat(msg, hasEntry("cause", THROWABLE));
+    }
+
+    @Test
+    void shouldBuildThrowableInNestedMessage() {
+        // Given:
+        customizer.ns("ns").withThrowable(THROWABLE);
+
+        // When:
+        final Map<String, Object> msg = customizer.build(true);
+
+        // Then:
+        assertThat(msg, not(hasKey("cause")));
+        assertThat(msg, hasEntry("ns", Map.of("cause", THROWABLE)));
+    }
+
+    @Test
+    void shouldBuildThrowableNotInMessage() {
+        // Given:
+        customizer.withThrowable(THROWABLE);
+
+        // When:
+        final Map<String, Object> msg = customizer.build(false);
+
+        // Then:
+        assertThat(msg, not(hasKey("cause")));
+    }
+
+    @Test
     void shouldThrowOnInvalidNamespace() {
         assertThrows(NullPointerException.class, () -> customizer.ns((String) null));
         assertThrows(IllegalArgumentException.class, () -> customizer.ns("\t"));
@@ -225,8 +262,8 @@ class DefaultLogEntryCustomizerTest {
         customizer.with("a", 10).ns("b").with("a", 22);
 
         // Then:
-        assertThat(customizer.build(), hasEntry("a", 10));
-        assertThat(customizer.build(), hasEntry("b", Map.of("a", 22)));
+        assertThat(customizer.build(false), hasEntry("a", 10));
+        assertThat(customizer.build(false), hasEntry("b", Map.of("a", 22)));
     }
 
     @Test
@@ -235,7 +272,7 @@ class DefaultLogEntryCustomizerTest {
         customizer.ns("empty");
 
         // Then:
-        assertThat(customizer.build(), not(hasKey("empty")));
+        assertThat(customizer.build(false), not(hasKey("empty")));
     }
 
     @Test
@@ -247,7 +284,7 @@ class DefaultLogEntryCustomizerTest {
         customizer.ns("ns").with("b", 20);
 
         // Then:
-        assertThat(customizer.build(), hasEntry("ns", Map.of("a", 10, "b", 20)));
+        assertThat(customizer.build(false), hasEntry("ns", Map.of("a", 10, "b", 20)));
     }
 
     @Test
@@ -256,7 +293,7 @@ class DefaultLogEntryCustomizerTest {
         customizer.ns(Namespace.someNs).with("a", 10);
 
         // Then:
-        assertThat(customizer.build(), hasEntry("someNs", Map.of("a", 10)));
+        assertThat(customizer.build(false), hasEntry("someNs", Map.of("a", 10)));
     }
 
     private enum MetricName {

--- a/logging/src/test/java/org/creekservice/internal/observability/logging/structured/JsonLogEntryFormatterTest.java
+++ b/logging/src/test/java/org/creekservice/internal/observability/logging/structured/JsonLogEntryFormatterTest.java
@@ -120,11 +120,8 @@ class JsonLogEntryFormatterTest {
         final String actual = formatter.formatInternal(e);
 
         // Then:
-        assertThat(
-                actual,
-                startsWith(
-                        "\"java.lang.OutOfMemoryError: some message\\n"
-                                + "\\tat creek.observability.logging@"));
+        assertThat(actual, startsWith("\"java.lang.OutOfMemoryError: some message"));
+        assertThat(actual, containsString("\\n\\tat creek.observability.logging@"));
         assertThat(
                 actual,
                 containsString(

--- a/logging/src/test/java/org/creekservice/internal/observability/logging/structured/JsonLogEntryFormatterTest.java
+++ b/logging/src/test/java/org/creekservice/internal/observability/logging/structured/JsonLogEntryFormatterTest.java
@@ -17,7 +17,10 @@
 package org.creekservice.internal.observability.logging.structured;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThrows;
 
 import java.math.BigDecimal;
@@ -29,7 +32,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.DoubleAdder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 class JsonLogEntryFormatterTest {
 
@@ -51,52 +53,52 @@ class JsonLogEntryFormatterTest {
 
     @Test
     void shouldNull() {
-        assertThat(formatter.format(null), is("null"));
+        assertThat(formatter.formatInternal(null), is("null"));
     }
 
     @Test
     void shouldFormatString() {
-        assertThat(formatter.format("some\btext"), is("\"some\\btext\""));
+        assertThat(formatter.formatInternal("some\b\"\n\ttext"), is("\"some\\b\\\"\\n\\ttext\""));
     }
 
     @Test
     void shouldFormatBigDecimal() {
-        assertThat(formatter.format(DECIMAL), is("1.35E-40"));
+        assertThat(formatter.formatInternal(DECIMAL), is("1.35E-40"));
     }
 
     @Test
     void shouldFormatDouble() {
-        assertThat(formatter.format(DOUBLE), is("1.7976931348623157E308"));
+        assertThat(formatter.formatInternal(DOUBLE), is("1.7976931348623157E308"));
     }
 
     @Test
     void shouldFormatFloat() {
-        assertThat(formatter.format(FLOAT), is("1.4E-45"));
+        assertThat(formatter.formatInternal(FLOAT), is("1.4E-45"));
     }
 
     @Test
     void shouldFormatByte() {
-        assertThat(formatter.format(BYTE), is("127"));
+        assertThat(formatter.formatInternal(BYTE), is("127"));
     }
 
     @Test
     void shouldFormatShort() {
-        assertThat(formatter.format(SHORT), is("32767"));
+        assertThat(formatter.formatInternal(SHORT), is("32767"));
     }
 
     @Test
     void shouldFormatInt() {
-        assertThat(formatter.format(INT), is("-2147483648"));
+        assertThat(formatter.formatInternal(INT), is("-2147483648"));
     }
 
     @Test
     void shouldFormatLong() {
-        assertThat(formatter.format(LONG), is("9223372036854775807"));
+        assertThat(formatter.formatInternal(LONG), is("9223372036854775807"));
     }
 
     @Test
     void shouldFormatOtherIntegerNumber() {
-        assertThat(formatter.format(new AtomicInteger(INT)), is("-2147483648"));
+        assertThat(formatter.formatInternal(new AtomicInteger(INT)), is("-2147483648"));
     }
 
     @Test
@@ -106,28 +108,64 @@ class JsonLogEntryFormatterTest {
         val.add(DOUBLE);
 
         // Then:
-        assertThat(formatter.format(val), is("1.7976931348623157E308"));
+        assertThat(formatter.formatInternal(val), is("1.7976931348623157E308"));
+    }
+
+    @Test
+    void shouldFormatThrowable() {
+        // Given:
+        final Throwable e = new OutOfMemoryError("some message");
+
+        // When:
+        final String actual = formatter.formatInternal(e);
+
+        // Then:
+        assertThat(
+                actual,
+                startsWith(
+                        "\"java.lang.OutOfMemoryError: some message\\n"
+                                + "\\tat creek.observability.logging@"));
+        assertThat(
+                actual,
+                containsString(
+                        "/org.creekservice.internal.observability.logging.structured"
+                            + ".JsonLogEntryFormatterTest.shouldFormatThrowable(JsonLogEntryFormatterTest.java:"));
+        assertThat(actual, endsWith("\""));
+    }
+
+    @Test
+    void shouldEscapeQuotesInThrowable() {
+        // Given:
+        final Throwable e = new OutOfMemoryError("some message with \"quoted text\"");
+
+        // When:
+        final String actual = formatter.formatInternal(e);
+
+        // Then:
+        assertThat(
+                actual,
+                startsWith("\"java.lang.OutOfMemoryError: some message with \\\"quoted text\\\""));
     }
 
     @Test
     void shouldFormatBoolean() {
-        assertThat(formatter.format(BOOLEAN), is("true"));
+        assertThat(formatter.formatInternal(BOOLEAN), is("true"));
     }
 
     @Test
     void shouldFormatCollection() {
-        assertThat(formatter.format(List.of(BOOLEAN, BYTE)), is("[true,127]"));
+        assertThat(formatter.formatInternal(List.of(BOOLEAN, BYTE)), is("[true,127]"));
     }
 
     @Test
     void shouldFormatNestedWithInCollection() {
-        assertThat(formatter.format(List.of(Map.of("a", BOOLEAN))), is("[{\"a\":true}]"));
+        assertThat(formatter.formatInternal(List.of(Map.of("a", BOOLEAN))), is("[{\"a\":true}]"));
     }
 
     @Test
     void shouldFormatMap() {
         assertThat(
-                formatter.format(new TreeMap<>(Map.of("a", BOOLEAN, "b", BYTE))),
+                formatter.formatInternal(new TreeMap<>(Map.of("a", BOOLEAN, "b", BYTE))),
                 is("{\"a\":true,\"b\":127}"));
     }
 
@@ -138,7 +176,7 @@ class JsonLogEntryFormatterTest {
 
     @Test
     void shouldConvertMapKeysToStrings() {
-        assertThat(formatter.format(Map.of(10, BOOLEAN)), is("{\"10\":true}"));
+        assertThat(formatter.formatInternal(Map.of(10, BOOLEAN)), is("{\"10\":true}"));
     }
 
     @Test
@@ -162,77 +200,79 @@ class JsonLogEntryFormatterTest {
 
     @Test
     void shouldFormatCharArray() {
-        assertThat(formatter.format(new char[] {}), is("[]"));
-        assertThat(formatter.format(new char[] {'a'}), is("[\"a\"]"));
-        assertThat(formatter.format(new char[] {'a', 'b'}), is("[\"a\",\"b\"]"));
-        assertThat(formatter.format(new char[] {'a', '\b'}), is("[\"a\",\"\\b\"]"));
+        assertThat(formatter.formatInternal(new char[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new char[] {'a'}), is("[\"a\"]"));
+        assertThat(formatter.formatInternal(new char[] {'a', 'b'}), is("[\"a\",\"b\"]"));
+        assertThat(formatter.formatInternal(new char[] {'a', '\b'}), is("[\"a\",\"\\b\"]"));
     }
 
     @Test
     void shouldFormatBooleanArray() {
-        assertThat(formatter.format(new boolean[] {}), is("[]"));
-        assertThat(formatter.format(new boolean[] {true}), is("[true]"));
-        assertThat(formatter.format(new boolean[] {true, false}), is("[true,false]"));
+        assertThat(formatter.formatInternal(new boolean[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new boolean[] {true}), is("[true]"));
+        assertThat(formatter.formatInternal(new boolean[] {true, false}), is("[true,false]"));
     }
 
     @Test
     void shouldFormatByteArray() {
-        assertThat(formatter.format(new byte[] {}), is("[]"));
-        assertThat(formatter.format(new byte[] {10}), is("[10]"));
-        assertThat(formatter.format(new byte[] {Byte.MIN_VALUE, Byte.MAX_VALUE}), is("[-128,127]"));
+        assertThat(formatter.formatInternal(new byte[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new byte[] {10}), is("[10]"));
+        assertThat(
+                formatter.formatInternal(new byte[] {Byte.MIN_VALUE, Byte.MAX_VALUE}),
+                is("[-128,127]"));
     }
 
     @Test
     void shouldFormatShortArray() {
-        assertThat(formatter.format(new short[] {}), is("[]"));
-        assertThat(formatter.format(new short[] {10}), is("[10]"));
+        assertThat(formatter.formatInternal(new short[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new short[] {10}), is("[10]"));
         assertThat(
-                formatter.format(new short[] {Short.MIN_VALUE, Short.MAX_VALUE}),
+                formatter.formatInternal(new short[] {Short.MIN_VALUE, Short.MAX_VALUE}),
                 is("[-32768,32767]"));
     }
 
     @Test
     void shouldFormatIntArray() {
-        assertThat(formatter.format(new int[] {}), is("[]"));
-        assertThat(formatter.format(new int[] {10}), is("[10]"));
+        assertThat(formatter.formatInternal(new int[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new int[] {10}), is("[10]"));
         assertThat(
-                formatter.format(new int[] {Integer.MIN_VALUE, Integer.MAX_VALUE}),
+                formatter.formatInternal(new int[] {Integer.MIN_VALUE, Integer.MAX_VALUE}),
                 is("[-2147483648,2147483647]"));
     }
 
     @Test
     void shouldFormatLongArray() {
-        assertThat(formatter.format(new long[] {}), is("[]"));
-        assertThat(formatter.format(new long[] {10}), is("[10]"));
+        assertThat(formatter.formatInternal(new long[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new long[] {10}), is("[10]"));
         assertThat(
-                formatter.format(new long[] {Long.MIN_VALUE, Long.MAX_VALUE}),
+                formatter.formatInternal(new long[] {Long.MIN_VALUE, Long.MAX_VALUE}),
                 is("[-9223372036854775808,9223372036854775807]"));
     }
 
     @Test
     void shouldFormatFloatArray() {
-        assertThat(formatter.format(new float[] {}), is("[]"));
-        assertThat(formatter.format(new float[] {10}), is("[10.0]"));
+        assertThat(formatter.formatInternal(new float[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new float[] {10}), is("[10.0]"));
         assertThat(
-                formatter.format(new float[] {Float.MIN_VALUE, Float.MAX_VALUE}),
+                formatter.formatInternal(new float[] {Float.MIN_VALUE, Float.MAX_VALUE}),
                 is("[1.4E-45,3.4028235E38]"));
     }
 
     @Test
     void shouldFormatDoubleArray() {
-        assertThat(formatter.format(new double[] {}), is("[]"));
-        assertThat(formatter.format(new double[] {10}), is("[10.0]"));
+        assertThat(formatter.formatInternal(new double[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new double[] {10}), is("[10.0]"));
         assertThat(
-                formatter.format(new double[] {Double.MIN_VALUE, Double.MAX_VALUE}),
+                formatter.formatInternal(new double[] {Double.MIN_VALUE, Double.MAX_VALUE}),
                 is("[4.9E-324,1.7976931348623157E308]"));
     }
 
     @Test
     void shouldFormatObjectArray() {
-        assertThat(formatter.format(new Object[] {}), is("[]"));
-        assertThat(formatter.format(new Object[] {10}), is("[10]"));
+        assertThat(formatter.formatInternal(new Object[] {}), is("[]"));
+        assertThat(formatter.formatInternal(new Object[] {10}), is("[10]"));
         assertThat(
-                formatter.format(new Object[] {new AtomicInteger(10), "hello\n"}),
+                formatter.formatInternal(new Object[] {new AtomicInteger(10), "hello\n"}),
                 is("[10,\"hello\\n\"]"));
     }
 
@@ -269,11 +309,10 @@ class JsonLogEntryFormatterTest {
         assertThat(e.getMessage(), is("Max depth of 8 exceeded"));
     }
 
-    @SetSystemProperty(key = JsonLogEntryFormatter.MAX_DEPTH_PROP, value = "8")
     @Test
     void shouldNotThrowIfMaxDepthMatched() {
         // Given:
-        final Map<String, ?> tooDeeplyNested =
+        final Map<String, ?> notTooDeeplyNested =
                 Map.of(
                         "1",
                         Map.of(
@@ -289,24 +328,8 @@ class JsonLogEntryFormatterTest {
                                                                 Map.of("7", Map.of("8", 1))))))));
 
         // When:
-        formatter.format(tooDeeplyNested);
+        formatter.formatInternal(notTooDeeplyNested);
 
         // Then: did not throw
-    }
-
-    @SetSystemProperty(key = JsonLogEntryFormatter.MAX_DEPTH_PROP, value = "3")
-    @Test
-    void shouldSupportCustomMaxDepth() {
-        // Given:
-        final Map<String, ?> tooDeeplyNested =
-                Map.of("1", Map.of("2", Map.of("3", Map.of("4", 1))));
-
-        // When:
-        final Exception e =
-                assertThrows(
-                        IllegalArgumentException.class, () -> formatter.format(tooDeeplyNested));
-
-        // Then:
-        assertThat(e.getMessage(), is("Max depth of 3 exceeded"));
     }
 }

--- a/logging/src/test/java/org/creekservice/internal/observability/logging/structured/JsonLoggingFunctionalTest.java
+++ b/logging/src/test/java/org/creekservice/internal/observability/logging/structured/JsonLoggingFunctionalTest.java
@@ -73,10 +73,10 @@ public class JsonLoggingFunctionalTest {
         final JsonNode ns = root.get("some\t\n\"ns");
         assertThat(
                 String.valueOf(ns.get("cause")),
-                startsWith(
-                        "\"java.lang.RuntimeException: some\\t\\n"
-                                + "\\\"cause\\n"
-                                + "\\tat creek.observability.logging@"));
+                startsWith("\"java.lang.RuntimeException: some\\t\\n\\\"cause"));
+        assertThat(
+                String.valueOf(ns.get("cause")),
+                containsString("\\n\\tat creek.observability.logging@"));
         assertThat(
                 String.valueOf(ns.get("cause")),
                 containsString(

--- a/logging/src/test/java/org/creekservice/internal/observability/logging/structured/JsonLoggingFunctionalTest.java
+++ b/logging/src/test/java/org/creekservice/internal/observability/logging/structured/JsonLoggingFunctionalTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022-2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.observability.logging.structured;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+public class JsonLoggingFunctionalTest {
+
+    @Mock private Logger slf4jLogger;
+    private Slf4jStructuredLogger logger;
+
+    @BeforeEach
+    void setUp() {
+        logger =
+                new Slf4jStructuredLogger(
+                        slf4jLogger,
+                        Optional.empty(),
+                        DefaultLogEntryCustomizer::create,
+                        new JsonLogEntryFormatter());
+    }
+
+    @Test
+    void shouldLogToValidJson() {
+        // Given:
+        when(slf4jLogger.isErrorEnabled()).thenReturn(true);
+        final Throwable cause = new RuntimeException("some\t\n\"cause");
+
+        // When:
+        logger.error(
+                "some\t\n\"message",
+                line -> line.with("a", "some\t\n\"value").ns("some\t\n\"ns").withThrowable(cause));
+
+        // Then:
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(slf4jLogger).error(captor.capture(), isNull(Throwable.class));
+        final JsonNode root = toJson(captor.getValue());
+
+        assertThat(String.valueOf(root.get("message")), is("\"some\\t\\n\\\"message\""));
+        assertThat(String.valueOf(root.get("a")), is("\"some\\t\\n\\\"value\""));
+
+        final JsonNode ns = root.get("some\t\n\"ns");
+        assertThat(
+                String.valueOf(ns.get("cause")),
+                startsWith(
+                        "\"java.lang.RuntimeException: some\\t\\n"
+                                + "\\\"cause\\n"
+                                + "\\tat creek.observability.logging@"));
+        assertThat(
+                String.valueOf(ns.get("cause")),
+                containsString(
+                        "/org.creekservice.internal.observability.logging.structured"
+                            + ".JsonLoggingFunctionalTest.shouldLogToValidJson(JsonLoggingFunctionalTest.java:"));
+    }
+
+    private JsonNode toJson(final String value) {
+        try {
+            final JsonMapper mapper = JsonMapper.builder().build();
+            return mapper.readTree(value);
+        } catch (final Exception e) {
+            throw new AssertionError("Invalid JSON: " + value, e);
+        }
+    }
+}

--- a/logging/src/test/java/org/creekservice/internal/observability/logging/structured/Slf4jStructuredLoggerTest.java
+++ b/logging/src/test/java/org/creekservice/internal/observability/logging/structured/Slf4jStructuredLoggerTest.java
@@ -22,6 +22,7 @@ import static org.creekservice.api.observability.logging.structured.Level.INFO;
 import static org.creekservice.api.observability.logging.structured.Level.TRACE;
 import static org.creekservice.api.observability.logging.structured.Level.WARN;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -67,7 +68,7 @@ class Slf4jStructuredLoggerTest {
                         slf4jLogger, Optional.empty(), customizerFactory, formatter);
 
         when(customizerFactory.apply(any())).thenReturn(customizer);
-        when(customizer.build()).thenReturn(LOG_STATE);
+        when(customizer.build(anyBoolean())).thenReturn(LOG_STATE);
         when(formatter.format(any())).thenReturn(LOG_LINE);
     }
 


### PR DESCRIPTION
Previously, the stacktrace was printed after the JSON log line. With this change the stacktrace becomes part of the JSON log line.

In addition, this change makes it possible to add the cause within a namespace.
