### PR TITLE
fix: use CREEK_PACKAGES_TOKEN secret for GitHub Packages Dependabot auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ registries:
     type: maven-repository
     url: https://maven.pkg.github.com/creek-service/
     username: x-access-token
-    password: ${{secrets.GITHUB_TOKEN}}
+    password: ${{secrets.CREEK_PACKAGES_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Fix Dependabot registry secret configuration to use the correct CREEK_PACKAGES_TOKEN org-level secret instead of the invalid GITHUB_TOKEN.